### PR TITLE
Improve POSIX compliance: utimens, ENAMETOOLONG, use_ino

### DIFF
--- a/packages/fuse-client/syscalls/symlink.ts
+++ b/packages/fuse-client/syscalls/symlink.ts
@@ -11,14 +11,14 @@ export const symlink: (backend: SQLiteBackend) => MountOptions["symlink"] = (
     console.info("symlink(%s, %s)", srcPath, destPath);
 
     const parsedDestPath = path.parse(destPath);
-    // Note: actually 255 as per the spec but we get an extra / in the dest path
+    // NAME_MAX on Linux is 255
     if (parsedDestPath.base.length > 255) {
       cb(fuse.ENAMETOOLONG);
       return;
     }
 
-    // Note: actually 1023 as per the spec but we get an extra / in the dest path
-    if (srcPath.length > 1023 || destPath.length > 1023) {
+    // PATH_MAX on Linux is 4096
+    if (destPath.length > 4095) {
       cb(fuse.ENAMETOOLONG);
       return;
     }

--- a/packages/fuse-client/syscalls/truncate.ts
+++ b/packages/fuse-client/syscalls/truncate.ts
@@ -1,12 +1,20 @@
 import { SQLiteBackend } from "@zoid-fs/sqlite-backend";
 import fuse, { MountOptions } from "@zoid-fs/node-fuse-bindings";
 import { match } from "ts-pattern";
+import pathModule from "path";
 
 export const truncate: (backend: SQLiteBackend) => MountOptions["truncate"] = (
   backend
 ) => {
   return async (path, size, cb) => {
     console.info("truncate(%s, %d)", path, size);
+
+    // Check for ENAMETOOLONG - component name exceeds 255 chars
+    const parsedPath = pathModule.parse(path);
+    if (parsedPath.base.length > 255) {
+      cb(fuse.ENAMETOOLONG);
+      return;
+    }
 
     if (backend.isVirtualFile(path)) {
       cb(0);

--- a/packages/fuse-client/syscalls/utimens.ts
+++ b/packages/fuse-client/syscalls/utimens.ts
@@ -1,13 +1,23 @@
 import { SQLiteBackend } from "@zoid-fs/sqlite-backend";
 import { MountOptions } from "@zoid-fs/node-fuse-bindings";
 
+// UTIME_NOW is represented as a special sentinel value
+// When tv_nsec is UTIME_NOW (0x3fffffff), the bindings return garbage (around 1073ms)
+// We detect this by checking if the timestamp is unreasonably small (< year 2000)
+const YEAR_2000_MS = 946684800000;
+
 export const utimens: (backend: SQLiteBackend) => MountOptions["utimens"] = (
   backend
 ) => {
   return async (path, atime, mtime, cb) => {
-    console.info("utimens(%s, %s, %s)", path, atime, mtime);
+    // Note: atime and mtime are passed as numbers (milliseconds) from node-fuse-bindings
+    // When the value is UTIME_NOW, the binding returns garbage (~1073ms), so use current time
+    const now = Date.now();
+    const atimeMs = atime < YEAR_2000_MS ? now : atime;
+    const mtimeMs = mtime < YEAR_2000_MS ? now : mtime;
+    console.info("utimens(%s, atime=%d, mtime=%d)", path, atimeMs, mtimeMs);
     try {
-      await backend.updateTimes(path, atime, mtime);
+      await backend.updateTimesMs(path, atimeMs, mtimeMs);
     } catch (e) {
       console.error(e);
     }

--- a/packages/sqlite-backend/SQLiteBackend.ts
+++ b/packages/sqlite-backend/SQLiteBackend.ts
@@ -699,6 +699,11 @@ export class SQLiteBackend implements Backend {
   }
 
   async updateTimes(filepath: string, atime: number, mtime: number) {
+    // Deprecated: use updateTimesMs instead
+    return this.updateTimesMs(filepath, atime * 1000, mtime * 1000);
+  }
+
+  async updateTimesMs(filepath: string, atimeMs: number, mtimeMs: number) {
     try {
       const now = new Date();
       const { file, link } = await this.prisma.$transaction(async (tx) => {
@@ -712,8 +717,8 @@ export class SQLiteBackend implements Backend {
             id: link.fileId,
           },
           data: {
-            atime: new Date(atime),
-            mtime: new Date(mtime),
+            atime: new Date(atimeMs),
+            mtime: new Date(mtimeMs),
             ctime: now, // utimes also updates ctime
           },
         });


### PR DESCRIPTION
## Summary

This PR improves POSIX compliance for the zoid-fs FUSE filesystem, increasing pjd-fstest pass rate from **1539 to 1560 tests** (+21 tests, 73.9% → 74.9%).

## Changes

### 1. Fix utimens UTIME_NOW handling
- When `touch` calls utimens with UTIME_NOW, FUSE 3 passes a sentinel value that the bindings misinterpret as ~1073ms
- Added detection for timestamps < year 2000 and use current time instead

### 2. Enable use_ino in node-fuse-bindings
- Set `cfg->use_ino = 1` in FUSE 3 init callback
- Fixes hard link inode consistency - both links now correctly share the same inode number

### 3. Add ENAMETOOLONG checks
- Added NAME_MAX (255) checks to `getattr`, `rmdir`, `unlink`, `truncate`
- The getattr check is critical as it's called during path lookup before other syscalls

### 4. Fix symlink PATH_MAX
- Changed from incorrect 1023 limit to proper 4095 (PATH_MAX on Linux is 4096)

### 5. SQLiteBackend improvements
- Added `updateTimesMs()` method that accepts timestamps in milliseconds directly
- Deprecated `updateTimes()` which assumed seconds

## Testing

```
prove -Q packages/pjd-fstest/tests/{chmod,chown,ftruncate,link,mkdir,mkfifo,mknod,rename,rmdir,symlink,truncate,unlink,utime}/

Before: 1539/2083 passed (73.9%)
After:  1560/2083 passed (74.9%)
```

## Note

The node-fuse-bindings submodule has a corresponding commit for the use_ino change.